### PR TITLE
Mark test as not running in case of error.

### DIFF
--- a/index.js
+++ b/index.js
@@ -111,6 +111,7 @@ Runner.prototype.run = function(src, capabilities, options, callback) {
 
     function ran(err, r) {
         if (err) {
+            self._running = false;
             return callback(err);
         }
 


### PR DESCRIPTION
I hit a case where I wanted to run tests on several devices for one of my projects. One of this devices was failing to parse my javascript (IE7), so the tests didn't run at all, making it time out.

The timeout is captured as an error instead of a failure (makes sense), but on a test run error, the module leaves the test as if it is running, so when I try to run the next browser, it complains saying that there is a test still running. So my test suite stops whenever I get to IE7, which is not desired, if my tests time out on IE7, I would like the runner to continue with the next browser.

This fixed it for me. Let me know of any comments or anything.
